### PR TITLE
Updated the URL of Travis badge because of transferring the ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Sensu-Plugins-StackStorm
-[![Build Status](https://travis-ci.org/userlocalhost/sensu-plugins-stackstorm.svg?branch=master)](https://travis-ci.org/userlocalhost/sensu-plugins-stackstorm)
+[![Build Status](https://travis-ci.org/sensu-plugins/sensu-plugins-stackstorm.svg?branch=master)](https://travis-ci.org/sensu-plugins/sensu-plugins-stackstorm)
 
 # Functionality
 


### PR DESCRIPTION
Because of the transferring the ownership, the Travis badge doesn't show correct status.
This patch updates README to fix it.